### PR TITLE
Reference this forked repo when creating a heroku app

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "WordPress on Heroku",
   "description": "Holy Grail WordPress project template for Heroku",
-  "repository": "https://github.com/anttiviljami/wordpress-heroku-docker-project",
+  "repository": "https://github.com/mitramejia/wordpress-heroku-docker-project",
   "keywords": ["wordpress", "aws", "s3", "mariadb", "mysql", "php", "php7"],
   "addons": [
      "heroku-redis",


### PR DESCRIPTION

![create_a_new_app___heroku](https://user-images.githubusercontent.com/2616517/27552100-101c786c-5a74-11e7-95fc-c0c71216764a.jpg)

![cursor_and_create_a_new_app___heroku](https://user-images.githubusercontent.com/2616517/27552154-340d2b40-5a74-11e7-8662-5febbebf9521.jpg)

I need to remove the reference to the original repo, to avoid heroku using the original composer.json instead of the one in this repo. Im' doing this because app creation at heroku fails because a komodini/language package is down, so when composer tries to download it, dosen't find it and the heroku build fails.